### PR TITLE
Fix/directpay android rn80

### DIFF
--- a/android/src/main/java/com/rnamazonpaymentservicesdk/DirectPayManager.java
+++ b/android/src/main/java/com/rnamazonpaymentservicesdk/DirectPayManager.java
@@ -56,7 +56,7 @@ public class DirectPayManager extends ViewGroupManager<FrameLayout> {
     /**
      * Handle "create" command (called from JS) and call createFragment method
      */
-   @Override
+    @Override
     public void receiveCommand(
         @NonNull FrameLayout root,
         int commandId,

--- a/android/src/main/java/com/rnamazonpaymentservicesdk/DirectPayManager.java
+++ b/android/src/main/java/com/rnamazonpaymentservicesdk/DirectPayManager.java
@@ -56,21 +56,16 @@ public class DirectPayManager extends ViewGroupManager<FrameLayout> {
     /**
      * Handle "create" command (called from JS) and call createFragment method
      */
-    @Override
+   @Override
     public void receiveCommand(
-            @NonNull FrameLayout root,
-            String commandId,
-            @Nullable ReadableArray args
+        @NonNull FrameLayout root,
+        int commandId,
+        @Nullable ReadableArray args
     ) {
-        super.receiveCommand(root, commandId, args);
         int reactNativeViewId = args.getInt(0);
-        int commandIdInt = Integer.parseInt(commandId);
 
-        switch (commandIdInt) {
-            case COMMAND_CREATE:
-                createFragment(root, reactNativeViewId);
-                break;
-            default: {}
+        if (commandId == COMMAND_CREATE) {
+            createFragment(root, reactNativeViewId);
         }
     }
 

--- a/src/views/DirectPayManager.tsx
+++ b/src/views/DirectPayManager.tsx
@@ -39,9 +39,7 @@ const DirectPayManager: React.FC<customCheckoutViewProps> = (props) => {
   const createFragment = (viewId: any) =>
     UIManager.dispatchViewManagerCommand(
       viewId,
-      // we are calling the 'create' command
-      // @ts-ignore
-      UIManager.DirectPay.Commands.create.toString(),
+      UIManager.getViewManagerConfig('DirectPay').Commands.create,
       [viewId]
     );
 


### PR DESCRIPTION
The DirectPay button stopped appearing on Android after upgrading to React Native 0.80.2 and rn-amazonpaymentservices v0.2.5.

- Fixed DirectPayManager.java to use the correct receiveCommand(int commandId) overload instead of the legacy String signature.
- Updated DirectPayManager.tsx to use UIManager.getViewManagerConfig('DirectPay').Commands.create instead of passing commandId as string.

Verified on RN 0.80.2:
- DirectPay button renders correctly again on Android.