### PR TITLE
feat: allow dynamic merchant label in Apple Pay summary items

### DIFF
--- a/ios/ApplePayModule.swift
+++ b/ios/ApplePayModule.swift
@@ -76,14 +76,12 @@ class ApplePayModule: NSObject, PKPaymentAuthorizationViewControllerDelegate {
         }
         
         //  UPDATED: Use the dynamic variable 'paymentLabel' instead of hardcoded "Total"
+        // Set Payment Total
         paymentRequest.paymentSummaryItems = [
             PKPaymentSummaryItem(label: paymentLabel, amount: amount)
         ]
         
-        // Set Payment Total
-        paymentRequest.paymentSummaryItems = [
-            PKPaymentSummaryItem(label: "Total", amount: amount)
-        ]
+       
 
         if !PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: paymentRequest.supportedNetworks) {
             rejecter("APPLE_PAY_UNAVAILABLE", "Apple Pay not supported with the provided networks", nil)

--- a/ios/ApplePayModule.swift
+++ b/ios/ApplePayModule.swift
@@ -43,6 +43,9 @@ class ApplePayModule: NSObject, PKPaymentAuthorizationViewControllerDelegate {
         let merchantIdentifier = paymentDetails["merchantIdentifier"] as? String ?? ""
         let countryCode = paymentDetails["countryCode"] as? String ?? "US"
         let currencyCode = paymentDetails["currencyCode"] as? String ?? "USD"
+
+        //  NEW: Extract the label from JS, or default to "Total" if missing
+        let paymentLabel = paymentDetails["label"] as? String ?? "Total"
         
         let supportedNetworksRaw = (paymentDetails["supportedNetworks"] as? [String]) ?? []
         
@@ -71,6 +74,11 @@ class ApplePayModule: NSObject, PKPaymentAuthorizationViewControllerDelegate {
             rejecter("MISSING_TRANSACTION_DETAILS", "Transaction details missing", nil)
             return
         }
+        
+        //  UPDATED: Use the dynamic variable 'paymentLabel' instead of hardcoded "Total"
+        paymentRequest.paymentSummaryItems = [
+            PKPaymentSummaryItem(label: paymentLabel, amount: amount)
+        ]
         
         // Set Payment Total
         paymentRequest.paymentSummaryItems = [


### PR DESCRIPTION
## Problem
Apple Pay requires the last line item in the payment summary to represent the Merchant Name (per Apple Human Interface Guidelines). Currently, the SDK hardcodes this label to "Total".

This causes Apple to reject apps during the review process because the user sees "Total: $X.XX" instead of "MerchantName: $X.XX".

## Solution
I have updated `ApplePayModule.swift` to make the label dynamic.
- The code now checks for an optional `label` property in the `paymentDetails` dictionary.
- If `label` is provided, it is used as the summary item label.
- If `label` is missing, it defaults to "Total" to maintain backward compatibility for existing users.

## Usage Example
```javascript
const applePaymentDetails = {
  displayAmount: '100.00',
  label: 'My Business Name', // ✅ Now supported
  merchantIdentifier: 'merchant.com.example',
  // ... other props
};

```
## Proof of Fix.

**Before (Rejected by Apple):**
![WhatsApp Image 2025-11-17 at 2 38 17 PM](https://github.com/user-attachments/assets/acb1205a-9d5d-4090-827b-d184fba52828)

**After (Fixed with Dynamic Label):**
<img width="397" height="828" alt="Screenshot 1447-05-28 at 11 14 02 AM" src="https://github.com/user-attachments/assets/399782bc-52cd-48cc-9591-8d3b79f6e386" />


